### PR TITLE
Added region support. Replaced preview by staging parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Or install it yourself as:
 Luis.configure do |config|
  config.id = "<id>"
  config.subscription_key ="<key>"
- config.is_preview_mod = true
+ config.is_staging = true
+ config.region = 'westus' # default
 end
 ```
 

--- a/lib/luis.rb
+++ b/lib/luis.rb
@@ -12,14 +12,17 @@ module Luis
 
   include HTTParty
   class << self
-   attr_accessor :id, :subscription_key, :is_preview_mod, :is_verbose
+    attr_accessor :id, :subscription_key, :is_staging, :is_verbose, :region
   end
-  API_BASE_URI = 'https://westus.api.cognitive.microsoft.com/luis/v2.0/apps/%{id}'.freeze
+  API_BASE_URI = 'https://%{region}.api.cognitive.microsoft.com/luis/v2.0/apps/%{id}'.freeze
 
   def self.api_uri
-    uri = API_BASE_URI % {id: id}
-    uri += '/preview' if is_preview_mod
-    uri
+    API_BASE_URI % {id: id, region: region}
+  end
+
+  def self.is_preview_mod= value
+    warn "[DEPRECATION] `is_preview_mod` is deprecated.  Please use `is_staging` instead."
+    self.is_staging = value
   end
 
   # Query method for the luis
@@ -45,8 +48,9 @@ module Luis
   end
 
   def self.default_options
-    options = { 'subscription-key' => subscription_key }
+    options = { 'subscription-key' => subscription_key, 'region' => 'westus' }
     options['verbose'] = true if is_verbose
+    options['staging'] = true if is_staging
     options
   end
 end

--- a/lib/luis/version.rb
+++ b/lib/luis/version.rb
@@ -1,3 +1,3 @@
 module Luis
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.2.0'.freeze
 end


### PR DESCRIPTION
Since LUIS is now available in Europe, this pull request adds support to configure region while defaulting to `westus`.
The path `/preview` for non-published apps is not valid anymore and is replaced by a staging option.

I changed the configuration attribute from `is_preview_mod` to `is_staging` to represent the query parameter in the API documentation.
Using `is_preview_mod` is still valid but brings up a deprecation warning.

Bumped version to 0.2.0 based on Semantic Versioning.